### PR TITLE
tsconfig, mapping: Automatically import type references

### DIFF
--- a/mapping.ts
+++ b/mapping.ts
@@ -1,7 +1,3 @@
-/// <reference path="./node_modules/assemblyscript/std/assembly.d.ts" />
-/// <reference path="./node_modules/the-graph-wasm/index.d.ts" />
-/// <reference path="./types/Marketplace/Marketplace.types.ts" />
-
 export function handleAuctionCreated(event: EthereumEvent): void {
   let auction = new Entity()
   let id = event.params[0].value.toString()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extend": "./node_modules/the-graph-wasm/tsconfig.json",
+  "compilerOptions": {
+    "types": ["the-graph-wasm"]
+  }
+}


### PR DESCRIPTION
This eliminates the need to manually include `/// <reference ... />` type references at the top of the mapping. It depends on a new feature in `the-graph-wasm` that still needs to be merged though (PR coming up). 