### PR TITLE
Add `yarn watch`, make `yarn deploy` not watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "build": "graph build subgraph.yaml",
     "build-ipfs": "graph build --ipfs /ip4/127.0.0.1/tcp/5001 subgraph.yaml",
     "build-wast": "graph build -t wast subgraph.yaml",
-    "deploy": "graph deploy subgraph.yaml --watch --verbosity debug --node http://127.0.0.1:8020/ --ipfs /ip4/127.0.0.1/tcp/5001 --subgraph-name decentraland"
+    "deploy": "graph deploy subgraph.yaml --verbosity debug --node http://127.0.0.1:8020/ --ipfs /ip4/127.0.0.1/tcp/5001 --subgraph-name decentraland",
+    "watch": "graph deploy subgraph.yaml --watch --verbosity debug --node http://127.0.0.1:8020/ --ipfs /ip4/127.0.0.1/tcp/5001 --subgraph-name decentraland"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.4.1",


### PR DESCRIPTION
So that I don't have to Ctrl-C out of watch mode on each deploy