### PR TITLE
Make Parcel owner and createdAt nullable

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -41,14 +41,14 @@ type Parcel @entity {
   district: District
   # Source unclear
   # estate: Estate
-  owner: Bytes!
+  owner: Bytes
   data: ParcelData
   lastTransferredAt: BigInt
   auctionOwner: Bytes
   auctionPrice: BigInt
   activeAuction: Auction
   auctions: [Auction!] @derivedFrom(field: "parcel")
-  createdAt: BigInt!
+  createdAt: BigInt
   updatedAt: BigInt
 
   # Defined in the REST API, source unclear


### PR DESCRIPTION
These fields are sometimes left unset in the entities, and querying them results in an error because of the non-nullable constraint in the schema.